### PR TITLE
User specified idle time

### DIFF
--- a/Aware/AppDelegate.swift
+++ b/Aware/AppDelegate.swift
@@ -9,15 +9,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // Redraw button every minute
     let buttonRefreshRate: NSTimeInterval = 60
 
-    // Reset timer after 2m of inactivity
-    let userInactivityTimeout: NSTimeInterval = 2 * 60
+    // After N seconds, reset the timer
+    var userIdleTimeout: NSTimeInterval = 0
+
+    // User configurable idle time in minutes (defaults to 2m)
+    //   defaults write com.github.josh.Aware idle -int 2
+    let defaultIdleKey = "idle"
+    let defaultIdle = 2
 
     // kCGAnyInputEventType isn't part of CGEventType enum
     // defined in <CoreGraphics/CGEventTypes.h>
     let AnyInputEventType = CGEventType(rawValue: UInt32.max)!
 
+    let defaults = NSUserDefaults.standardUserDefaults()
+
     func applicationDidFinishLaunching(notification: NSNotification) {
         timerStart = NSDate()
+
+        let idleValue = (defaults.objectForKey(defaultIdleKey) as? Int) ?? defaultIdle
+        userIdleTimeout = Double(idleValue * 60)
 
         updateButton()
         NSTimer.scheduledTimer(buttonRefreshRate, userInfo: nil, repeats: true) { _ in self.updateButton() }
@@ -25,7 +35,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func updateButton() {
         let sinceUserActivity = CGEventSourceSecondsSinceLastEventType(.CombinedSessionState, AnyInputEventType)
-        if (sinceUserActivity > userInactivityTimeout) {
+        if (sinceUserActivity > userIdleTimeout) {
             timerStart = NSDate()
             updateButton()
         }

--- a/Aware/AppDelegate.swift
+++ b/Aware/AppDelegate.swift
@@ -10,12 +10,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let buttonRefreshRate: NSTimeInterval = 60
 
     // After N seconds, reset the timer
-    var userIdleTimeout: NSTimeInterval = 0
+    var userIdleSeconds: NSTimeInterval = 0
 
-    // User configurable idle time in minutes (defaults to 2m)
-    //   defaults write com.github.josh.Aware idle -int 2
-    let defaultIdleKey = "idle"
-    let defaultIdle = 2
+    // User configurable idle time in seconds (defaults to 2 minutes)
+    //   defaults write com.github.josh.Aware userIdleSeconds -int 120
+    let defaultUserIdleSecondsKey = "userIdleSeconds"
+    let defaultUserIdleSeconds: NSTimeInterval = 2 * 60
 
     // kCGAnyInputEventType isn't part of CGEventType enum
     // defined in <CoreGraphics/CGEventTypes.h>
@@ -26,8 +26,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(notification: NSNotification) {
         timerStart = NSDate()
 
-        let idleValue = (defaults.objectForKey(defaultIdleKey) as? Int) ?? defaultIdle
-        userIdleTimeout = Double(idleValue * 60)
+        userIdleSeconds = ((defaults.objectForKey(defaultUserIdleSecondsKey) as? NSTimeInterval) ?? defaultUserIdleSeconds)
 
         updateButton()
         NSTimer.scheduledTimer(buttonRefreshRate, userInfo: nil, repeats: true) { _ in self.updateButton() }
@@ -35,7 +34,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func updateButton() {
         let sinceUserActivity = CGEventSourceSecondsSinceLastEventType(.CombinedSessionState, AnyInputEventType)
-        if (sinceUserActivity > userIdleTimeout) {
+        if (sinceUserActivity > userIdleSeconds) {
             timerStart = NSDate()
             updateButton()
         }


### PR DESCRIPTION
As requested by #1, this would allow the user to customize the user activity idle timeout.

Currently theres no UI for it, but you can use the CLI to set the value.

``` sh
$ defaults write com.github.josh.Aware idle -int 10
```

Still trying to come up with a better name for the keyword value. Some naming idea keywords, `user`, `activity`, `inactivity`, `system`, `idle`, `interaction`, `timeout`.
- `idleTimeout`
- `inactivityTimeout`
- `userActivityTimeout`
- `userIdleMinutes`

Also, should it be minutes? Maybe seconds so it could be set to 30 seconds or something. Not sure.
## 

CC: @pmarsceill
References: #1
