### PR TITLE
"Reset after" preference menu

### DIFF
--- a/Aware.xcodeproj/project.pbxproj
+++ b/Aware.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		036EBD191C1408C200121D0B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036EBD181C1408C200121D0B /* AppDelegate.swift */; };
 		036EBD1B1C1408C200121D0B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 036EBD1A1C1408C200121D0B /* Assets.xcassets */; };
 		036EBD1E1C1408C200121D0B /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 036EBD1C1C1408C200121D0B /* MainMenu.xib */; };
+		037624F41C699C1C0048B6C8 /* TimeIntervalMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037624F31C699C1C0048B6C8 /* TimeIntervalMenuItem.swift */; };
 		03F9E2311C24CCA8001DBE86 /* NSTimeIntervalFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F9E2301C24CCA8001DBE86 /* NSTimeIntervalFormatter.swift */; };
 		03F9E2331C24CD2E001DBE86 /* NSTimeIntervalFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F9E2321C24CD2E001DBE86 /* NSTimeIntervalFormatterTests.swift */; };
 		03F9E2341C24CDAB001DBE86 /* NSTimeIntervalFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F9E2301C24CCA8001DBE86 /* NSTimeIntervalFormatter.swift */; };
@@ -33,6 +34,7 @@
 		036EBD1A1C1408C200121D0B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		036EBD1D1C1408C200121D0B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		036EBD1F1C1408C200121D0B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		037624F31C699C1C0048B6C8 /* TimeIntervalMenuItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeIntervalMenuItem.swift; sourceTree = "<group>"; };
 		038D0B381C4DDD5600040C44 /* Aware.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Aware.entitlements; sourceTree = "<group>"; };
 		03F9E2261C24CAD3001DBE86 /* AwareTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AwareTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		03F9E22A1C24CAD3001DBE86 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -80,6 +82,7 @@
 			isa = PBXGroup;
 			children = (
 				036EBD181C1408C200121D0B /* AppDelegate.swift */,
+				037624F31C699C1C0048B6C8 /* TimeIntervalMenuItem.swift */,
 				03F9E2301C24CCA8001DBE86 /* NSTimeIntervalFormatter.swift */,
 				0337E7861C14E37B003A8150 /* NSTimer+Block.swift */,
 				036EBD1A1C1408C200121D0B /* Assets.xcassets */,
@@ -204,6 +207,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				037624F41C699C1C0048B6C8 /* TimeIntervalMenuItem.swift in Sources */,
 				03F9E2311C24CCA8001DBE86 /* NSTimeIntervalFormatter.swift in Sources */,
 				036EBD191C1408C200121D0B /* AppDelegate.swift in Sources */,
 				0337E7871C14E37B003A8150 /* NSTimer+Block.swift in Sources */,

--- a/Aware.xcodeproj/project.pbxproj
+++ b/Aware.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		036EBD1B1C1408C200121D0B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 036EBD1A1C1408C200121D0B /* Assets.xcassets */; };
 		036EBD1E1C1408C200121D0B /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 036EBD1C1C1408C200121D0B /* MainMenu.xib */; };
 		037624F41C699C1C0048B6C8 /* TimeIntervalMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 037624F31C699C1C0048B6C8 /* TimeIntervalMenuItem.swift */; };
+		03E1061D1C6FE38B0070BC82 /* TimeIntervalMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03E1061C1C6FE38B0070BC82 /* TimeIntervalMenu.swift */; };
 		03F9E2311C24CCA8001DBE86 /* NSTimeIntervalFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F9E2301C24CCA8001DBE86 /* NSTimeIntervalFormatter.swift */; };
 		03F9E2331C24CD2E001DBE86 /* NSTimeIntervalFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F9E2321C24CD2E001DBE86 /* NSTimeIntervalFormatterTests.swift */; };
 		03F9E2341C24CDAB001DBE86 /* NSTimeIntervalFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03F9E2301C24CCA8001DBE86 /* NSTimeIntervalFormatter.swift */; };
@@ -36,6 +37,7 @@
 		036EBD1F1C1408C200121D0B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		037624F31C699C1C0048B6C8 /* TimeIntervalMenuItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeIntervalMenuItem.swift; sourceTree = "<group>"; };
 		038D0B381C4DDD5600040C44 /* Aware.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = Aware.entitlements; sourceTree = "<group>"; };
+		03E1061C1C6FE38B0070BC82 /* TimeIntervalMenu.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeIntervalMenu.swift; sourceTree = "<group>"; };
 		03F9E2261C24CAD3001DBE86 /* AwareTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = AwareTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		03F9E22A1C24CAD3001DBE86 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		03F9E2301C24CCA8001DBE86 /* NSTimeIntervalFormatter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTimeIntervalFormatter.swift; sourceTree = "<group>"; };
@@ -82,6 +84,7 @@
 			isa = PBXGroup;
 			children = (
 				036EBD181C1408C200121D0B /* AppDelegate.swift */,
+				03E1061C1C6FE38B0070BC82 /* TimeIntervalMenu.swift */,
 				037624F31C699C1C0048B6C8 /* TimeIntervalMenuItem.swift */,
 				03F9E2301C24CCA8001DBE86 /* NSTimeIntervalFormatter.swift */,
 				0337E7861C14E37B003A8150 /* NSTimer+Block.swift */,
@@ -207,6 +210,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				03E1061D1C6FE38B0070BC82 /* TimeIntervalMenu.swift in Sources */,
 				037624F41C699C1C0048B6C8 /* TimeIntervalMenuItem.swift in Sources */,
 				03F9E2311C24CCA8001DBE86 /* NSTimeIntervalFormatter.swift in Sources */,
 				036EBD191C1408C200121D0B /* AppDelegate.swift in Sources */,

--- a/Aware/AppDelegate.swift
+++ b/Aware/AppDelegate.swift
@@ -94,4 +94,27 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         str.addAttributes(attributes, range: NSMakeRange(0, str.length))
         return str
     }
+
+    @IBAction func setUserIdleSecondsFromMenuItem(menuItem: NSMenuItem) {
+        var seconds: NSTimeInterval?
+
+        switch menuItem.title {
+        case "1 minute": seconds = 60
+        case "2 minutes": seconds = 120
+        case "5 minutes": seconds = 300
+        case "10 minutes": seconds = 600
+        case "30 minutes": seconds = 1800
+        default: seconds = nil
+        }
+
+        let defaults = NSUserDefaults.standardUserDefaults()
+        if let seconds = seconds {
+            defaults.setDouble(seconds, forKey: "userIdleSeconds")
+        } else {
+            defaults.removeObjectForKey("userIdleSeconds")
+        }
+
+        // Recompute lazy userIdleSeconds property
+        userIdleSeconds = self.readUserIdleSeconds()
+    }
 }

--- a/Aware/AppDelegate.swift
+++ b/Aware/AppDelegate.swift
@@ -108,10 +108,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @IBAction func setUserIdleSecondsFromMenuItem(menuItem: TimeIntervalMenuItem) {
-        let defaults = NSUserDefaults.standardUserDefaults()
-        defaults.setDouble(menuItem.value, forKey: "userIdleSeconds")
+        userIdleSeconds = menuItem.value
 
-        // Recompute userIdleSeconds property
-        userIdleSeconds = self.readUserIdleSeconds()
+        // Persist new value
+        let defaults = NSUserDefaults.standardUserDefaults()
+        defaults.setDouble(userIdleSeconds, forKey: "userIdleSeconds")
     }
 }

--- a/Aware/AppDelegate.swift
+++ b/Aware/AppDelegate.swift
@@ -19,7 +19,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     var mouseEventMonitor: AnyObject?
 
     // User configurable idle time in seconds (defaults to 2 minutes)
-    lazy var userIdleSeconds: NSTimeInterval = self.readUserIdleSeconds()
+    var userIdleSeconds: NSTimeInterval = 120 {
+        didSet {
+            userIdleSecondsMenu.setTimeInterval(userIdleSeconds)
+        }
+    }
+
     func readUserIdleSeconds() -> NSTimeInterval {
         let defaults = NSUserDefaults.standardUserDefaults()
         let defaultsValue = defaults.objectForKey("userIdleSeconds") as? NSTimeInterval
@@ -37,8 +42,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    @IBOutlet weak var userIdleSecondsMenu: TimeIntervalMenu!
+
     func applicationDidFinishLaunching(notification: NSNotification) {
         updateButton()
+        self.userIdleSeconds = self.readUserIdleSeconds()
+
         NSTimer.scheduledTimer(buttonRefreshRate, userInfo: nil, repeats: true) { _ in self.updateButton() }
 
         let notificationCenter = NSWorkspace.sharedWorkspace().notificationCenter
@@ -99,7 +108,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let defaults = NSUserDefaults.standardUserDefaults()
         defaults.setDouble(menuItem.value, forKey: "userIdleSeconds")
 
-        // Recompute lazy userIdleSeconds property
+        // Recompute userIdleSeconds property
         userIdleSeconds = self.readUserIdleSeconds()
     }
 }

--- a/Aware/AppDelegate.swift
+++ b/Aware/AppDelegate.swift
@@ -95,24 +95,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return str
     }
 
-    @IBAction func setUserIdleSecondsFromMenuItem(menuItem: NSMenuItem) {
-        var seconds: NSTimeInterval?
-
-        switch menuItem.title {
-        case "1 minute": seconds = 60
-        case "2 minutes": seconds = 120
-        case "5 minutes": seconds = 300
-        case "10 minutes": seconds = 600
-        case "30 minutes": seconds = 1800
-        default: seconds = nil
-        }
-
+    @IBAction func setUserIdleSecondsFromMenuItem(menuItem: TimeIntervalMenuItem) {
         let defaults = NSUserDefaults.standardUserDefaults()
-        if let seconds = seconds {
-            defaults.setDouble(seconds, forKey: "userIdleSeconds")
-        } else {
-            defaults.removeObjectForKey("userIdleSeconds")
-        }
+        defaults.setDouble(menuItem.value, forKey: "userIdleSeconds")
 
         // Recompute lazy userIdleSeconds property
         userIdleSeconds = self.readUserIdleSeconds()

--- a/Aware/AppDelegate.swift
+++ b/Aware/AppDelegate.swift
@@ -18,8 +18,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // Reference to installed global mouse event monitor
     var mouseEventMonitor: AnyObject?
 
+    // Default value to initialize userIdleSeconds to
+    static let defaultUserIdleSeconds: NSTimeInterval = 120
+
     // User configurable idle time in seconds (defaults to 2 minutes)
-    var userIdleSeconds: NSTimeInterval = 120 {
+    var userIdleSeconds: NSTimeInterval = defaultUserIdleSeconds {
         didSet {
             userIdleSecondsMenu.setTimeInterval(userIdleSeconds)
         }
@@ -28,7 +31,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func readUserIdleSeconds() -> NSTimeInterval {
         let defaults = NSUserDefaults.standardUserDefaults()
         let defaultsValue = defaults.objectForKey("userIdleSeconds") as? NSTimeInterval
-        return defaultsValue ?? 120
+        return defaultsValue ?? self.dynamicType.defaultUserIdleSeconds
     }
 
     // kCGAnyInputEventType isn't part of CGEventType enum

--- a/Aware/Base.lproj/MainMenu.xib
+++ b/Aware/Base.lproj/MainMenu.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15A278b" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
@@ -19,6 +19,44 @@
         </customObject>
         <menu id="099-Sz-hJX">
             <items>
+                <menuItem title="Reset after" id="MxL-Ze-gT6">
+                    <modifierMask key="keyEquivalentModifierMask" shift="YES"/>
+                    <menu key="submenu" title="Reset after" id="E7T-Ns-G2B">
+                        <items>
+                            <menuItem title="1 Minute" id="Uxu-Qk-tKG">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="setUserIdleSecondsFromMenuItem:" target="Voe-Tx-rLC" id="Eci-m6-2dl"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="2 Minutes" id="gcp-c8-GKt">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="setUserIdleSecondsFromMenuItem:" target="Voe-Tx-rLC" id="sKX-eE-j9c"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="5 Minutes" id="Q1r-Fn-WZP">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="setUserIdleSecondsFromMenuItem:" target="Voe-Tx-rLC" id="xdI-bD-Jfo"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="10 Minutes" id="ybu-UV-FrJ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="setUserIdleSecondsFromMenuItem:" target="Voe-Tx-rLC" id="l5k-1Y-M3s"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="30 Minutes" id="SgD-zg-YUU">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="setUserIdleSecondsFromMenuItem:" target="Voe-Tx-rLC" id="oKb-5M-a6k"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem isSeparatorItem="YES" id="uxS-lo-hf3"/>
                 <menuItem title="Quit Aware" id="nuW-Ky-b5C">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>

--- a/Aware/Base.lproj/MainMenu.xib
+++ b/Aware/Base.lproj/MainMenu.xib
@@ -15,13 +15,14 @@
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Aware" customModuleProvider="target">
             <connections>
                 <outlet property="menu" destination="099-Sz-hJX" id="FtV-pF-bQq"/>
+                <outlet property="userIdleSecondsMenu" destination="E7T-Ns-G2B" id="oBR-eT-oYL"/>
             </connections>
         </customObject>
         <menu id="099-Sz-hJX">
             <items>
                 <menuItem title="Reset after" id="MxL-Ze-gT6">
                     <modifierMask key="keyEquivalentModifierMask" shift="YES"/>
-                    <menu key="submenu" title="Reset after" id="E7T-Ns-G2B">
+                    <menu key="submenu" title="Reset after" id="E7T-Ns-G2B" customClass="TimeIntervalMenu" customModule="Aware" customModuleProvider="target">
                         <items>
                             <menuItem title="1 Minute" id="Uxu-Qk-tKG" customClass="TimeIntervalMenuItem" customModule="Aware" customModuleProvider="target">
                                 <modifierMask key="keyEquivalentModifierMask"/>

--- a/Aware/Base.lproj/MainMenu.xib
+++ b/Aware/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15A278b" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9532"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -23,32 +23,57 @@
                     <modifierMask key="keyEquivalentModifierMask" shift="YES"/>
                     <menu key="submenu" title="Reset after" id="E7T-Ns-G2B">
                         <items>
-                            <menuItem title="1 Minute" id="Uxu-Qk-tKG">
+                            <menuItem title="1 Minute" id="Uxu-Qk-tKG" customClass="TimeIntervalMenuItem" customModule="Aware" customModuleProvider="target">
                                 <modifierMask key="keyEquivalentModifierMask"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="value">
+                                        <integer key="value" value="60"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                                 <connections>
                                     <action selector="setUserIdleSecondsFromMenuItem:" target="Voe-Tx-rLC" id="Eci-m6-2dl"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="2 Minutes" id="gcp-c8-GKt">
+                            <menuItem title="2 Minutes" id="gcp-c8-GKt" customClass="TimeIntervalMenuItem" customModule="Aware" customModuleProvider="target">
                                 <modifierMask key="keyEquivalentModifierMask"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="value">
+                                        <integer key="value" value="120"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                                 <connections>
                                     <action selector="setUserIdleSecondsFromMenuItem:" target="Voe-Tx-rLC" id="sKX-eE-j9c"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="5 Minutes" id="Q1r-Fn-WZP">
+                            <menuItem title="5 Minutes" id="Q1r-Fn-WZP" customClass="TimeIntervalMenuItem" customModule="Aware" customModuleProvider="target">
                                 <modifierMask key="keyEquivalentModifierMask"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="value">
+                                        <integer key="value" value="300"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                                 <connections>
                                     <action selector="setUserIdleSecondsFromMenuItem:" target="Voe-Tx-rLC" id="xdI-bD-Jfo"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="10 Minutes" id="ybu-UV-FrJ">
+                            <menuItem title="10 Minutes" id="ybu-UV-FrJ" customClass="TimeIntervalMenuItem" customModule="Aware" customModuleProvider="target">
                                 <modifierMask key="keyEquivalentModifierMask"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="value">
+                                        <integer key="value" value="600"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                                 <connections>
                                     <action selector="setUserIdleSecondsFromMenuItem:" target="Voe-Tx-rLC" id="l5k-1Y-M3s"/>
                                 </connections>
                             </menuItem>
-                            <menuItem title="30 Minutes" id="SgD-zg-YUU">
+                            <menuItem title="30 Minutes" id="SgD-zg-YUU" customClass="TimeIntervalMenuItem" customModule="Aware" customModuleProvider="target">
                                 <modifierMask key="keyEquivalentModifierMask"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="value">
+                                        <integer key="value" value="1800"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                                 <connections>
                                     <action selector="setUserIdleSecondsFromMenuItem:" target="Voe-Tx-rLC" id="oKb-5M-a6k"/>
                                 </connections>

--- a/Aware/TimeIntervalMenu.swift
+++ b/Aware/TimeIntervalMenu.swift
@@ -1,0 +1,19 @@
+//
+//  TimeIntervalMenu.swift
+//  Aware
+//
+//  Created by Joshua Peek on 2/13/16.
+//  Copyright © 2016 Joshua Peek. All rights reserved.
+//
+
+import Cocoa
+
+class TimeIntervalMenu: NSMenu {
+    func setTimeInterval(ti: NSTimeInterval) {
+        for item in itemArray {
+            if let timeIntervalItem = item as? TimeIntervalMenuItem {
+                item.state = timeIntervalItem.value == ti ? 1 : 0
+            }
+        }
+    }
+}

--- a/Aware/TimeIntervalMenuItem.swift
+++ b/Aware/TimeIntervalMenuItem.swift
@@ -1,5 +1,5 @@
 //
-//  NumberMenuItem.swift
+//  TimeIntervalMenuItem.swift
 //  Aware
 //
 //  Created by Joshua Peek on 2/8/16.

--- a/Aware/TimeIntervalMenuItem.swift
+++ b/Aware/TimeIntervalMenuItem.swift
@@ -1,0 +1,14 @@
+//
+//  NumberMenuItem.swift
+//  Aware
+//
+//  Created by Joshua Peek on 2/8/16.
+//  Copyright © 2016 Joshua Peek. All rights reserved.
+//
+
+import Cocoa
+
+@IBDesignable
+class TimeIntervalMenuItem: NSMenuItem {
+    @IBInspectable var value: NSTimeInterval = 0
+}


### PR DESCRIPTION
Rough UI implementation of #1 feature requested by @pmarsceill.

<img width="299" alt="screen shot 2015-12-29 at 3 53 33 pm" src="https://cloud.githubusercontent.com/assets/137/12042842/8141e384-ae44-11e5-8d2f-0fa92cf93b45.png">
- Doesn't handle current "selected" preference. Would need to figure out what to display if "default" is manually set to a non-preset option (via `defaults write com.github.josh.Aware userIdleSeconds -int 10`)
- Unsure of the usefulness of the other defaults. So far I'm liking "2 minute" idle time. Though, I still need to do some real world testing on other machines.
