### PR TITLE
Add "Start at login" menu item

### DIFF
--- a/Aware.xcodeproj/project.pbxproj
+++ b/Aware.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		031DF82B1C3442BA009E00DD /* SessionLoginItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031DF82A1C3442BA009E00DD /* SessionLoginItems.swift */; };
+		031DF82D1C345AF2009E00DD /* SharedFileList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 031DF82C1C345AF2009E00DD /* SharedFileList.swift */; };
 		0337E7871C14E37B003A8150 /* NSTimer+Block.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0337E7861C14E37B003A8150 /* NSTimer+Block.swift */; };
 		036EBD191C1408C200121D0B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 036EBD181C1408C200121D0B /* AppDelegate.swift */; };
 		036EBD1B1C1408C200121D0B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 036EBD1A1C1408C200121D0B /* Assets.xcassets */; };
@@ -27,6 +29,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		031DF82A1C3442BA009E00DD /* SessionLoginItems.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SessionLoginItems.swift; sourceTree = "<group>"; };
+		031DF82C1C345AF2009E00DD /* SharedFileList.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SharedFileList.swift; sourceTree = "<group>"; };
 		0337E7861C14E37B003A8150 /* NSTimer+Block.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSTimer+Block.swift"; sourceTree = "<group>"; };
 		036EBD151C1408C200121D0B /* Aware.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Aware.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		036EBD181C1408C200121D0B /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -79,11 +83,13 @@
 			isa = PBXGroup;
 			children = (
 				036EBD181C1408C200121D0B /* AppDelegate.swift */,
+				036EBD1A1C1408C200121D0B /* Assets.xcassets */,
+				036EBD1F1C1408C200121D0B /* Info.plist */,
+				031DF82A1C3442BA009E00DD /* SessionLoginItems.swift */,
+				036EBD1C1C1408C200121D0B /* MainMenu.xib */,
 				03F9E2301C24CCA8001DBE86 /* NSTimeIntervalFormatter.swift */,
 				0337E7861C14E37B003A8150 /* NSTimer+Block.swift */,
-				036EBD1A1C1408C200121D0B /* Assets.xcassets */,
-				036EBD1C1C1408C200121D0B /* MainMenu.xib */,
-				036EBD1F1C1408C200121D0B /* Info.plist */,
+				031DF82C1C345AF2009E00DD /* SharedFileList.swift */,
 			);
 			path = Aware;
 			sourceTree = "<group>";
@@ -197,8 +203,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				031DF82D1C345AF2009E00DD /* SharedFileList.swift in Sources */,
 				03F9E2311C24CCA8001DBE86 /* NSTimeIntervalFormatter.swift in Sources */,
 				036EBD191C1408C200121D0B /* AppDelegate.swift in Sources */,
+				031DF82B1C3442BA009E00DD /* SessionLoginItems.swift in Sources */,
 				0337E7871C14E37B003A8150 /* NSTimer+Block.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Aware/AppDelegate.swift
+++ b/Aware/AppDelegate.swift
@@ -10,6 +10,8 @@ import Cocoa
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
+    let appURL: NSURL = NSURL.fileURLWithPath(NSBundle.mainBundle().bundlePath)
+
     var timerStart: NSDate = NSDate()
 
     // Redraw button every minute
@@ -43,6 +45,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let notificationCenter = NSWorkspace.sharedWorkspace().notificationCenter
         notificationCenter.addObserverForName(NSWorkspaceWillSleepNotification, object: nil, queue: nil) { _ in self.resetTimer() }
         notificationCenter.addObserverForName(NSWorkspaceDidWakeNotification, object: nil, queue: nil) { _ in self.resetTimer() }
+
+        if SessionLoginItems.findURL(appURL) != nil {
+            startAtLoginMenuItem.state = 1
+        }
     }
 
     func resetTimer() {
@@ -58,5 +64,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let duration = NSDate().timeIntervalSinceDate(timerStart)
         statusItem.button!.title = NSTimeIntervalFormatter().stringFromTimeInterval(duration)
+    }
+
+    @IBOutlet weak var startAtLoginMenuItem: NSMenuItem!
+
+    @IBAction func toggleStartAtLogin(menuItem: NSMenuItem) {
+        if menuItem.state == 1 {
+            SessionLoginItems.removeURL(appURL)
+            menuItem.state = 0
+        } else {
+            SessionLoginItems.addURL(appURL)
+            menuItem.state = 1
+        }
     }
 }

--- a/Aware/Base.lproj/MainMenu.xib
+++ b/Aware/Base.lproj/MainMenu.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="9531" systemVersion="15A278b" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="9531"/>
@@ -15,10 +15,18 @@
         <customObject id="Voe-Tx-rLC" customClass="AppDelegate" customModule="Aware" customModuleProvider="target">
             <connections>
                 <outlet property="menu" destination="099-Sz-hJX" id="FtV-pF-bQq"/>
+                <outlet property="startAtLoginMenuItem" destination="XIJ-xv-usZ" id="ljA-7i-Ru5"/>
             </connections>
         </customObject>
         <menu id="099-Sz-hJX">
             <items>
+                <menuItem title="Start at login" id="XIJ-xv-usZ">
+                    <modifierMask key="keyEquivalentModifierMask"/>
+                    <connections>
+                        <action selector="toggleStartAtLogin:" target="Voe-Tx-rLC" id="Ypm-ih-b2l"/>
+                    </connections>
+                </menuItem>
+                <menuItem isSeparatorItem="YES" id="MCF-Da-aV2"/>
                 <menuItem title="Quit Aware" id="nuW-Ky-b5C">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>

--- a/Aware/SessionLoginItems.swift
+++ b/Aware/SessionLoginItems.swift
@@ -1,0 +1,45 @@
+//
+//  LoginItems.swift
+//  Aware
+//
+//  Created by Joshua Peek on 12/30/15.
+//  Copyright © 2015 Joshua Peek. All rights reserved.
+//
+
+import Foundation
+
+@available(OSX, deprecated=10.11)
+struct SessionLoginItems {
+    static func addURL(url: NSURL) {
+        guard let list = SharedFileList.create(SharedFileList.sessionLoginItems) else {
+            return
+        }
+
+        SharedFileList.insertItemURL(list, afterItem: SharedFileList.itemBeforeFirst, url: url)
+    }
+
+    static func removeURL(url: NSURL) {
+        guard let list = SharedFileList.create(SharedFileList.sessionLoginItems) else {
+            return
+        }
+
+        if let item = findURL(url) {
+            SharedFileList.removeItem(list, item: item)
+        }
+    }
+
+    static func findURL(url: NSURL) -> SharedFileList.Item? {
+        guard let list = SharedFileList.create(SharedFileList.sessionLoginItems),
+                 items = SharedFileList.copySnapshot(list) as? [LSSharedFileListItemRef] else {
+            return nil
+        }
+
+        for item in items {
+            if let url = SharedFileList.copyResolvedURL(item) where url.isEqual(url) {
+                return item
+            }
+        }
+
+        return nil
+    }
+}

--- a/Aware/SharedFileList.swift
+++ b/Aware/SharedFileList.swift
@@ -1,0 +1,46 @@
+//
+//  SharedFileList.swift
+//  Aware
+//
+//  Created by Joshua Peek on 12/30/15.
+//  Copyright © 2015 Joshua Peek. All rights reserved.
+//
+
+import Foundation
+
+@available(OSX, deprecated=10.11)
+struct SharedFileList {
+    typealias List = LSSharedFileListRef
+    typealias Item = LSSharedFileListItemRef
+
+    // "com.apple.LSSharedFileList.SessionLoginItems"
+    static let sessionLoginItems: String = kLSSharedFileListSessionLoginItems.takeRetainedValue() as String
+
+    static let itemBeforeFirst: Item = kLSSharedFileListItemBeforeFirst.takeRetainedValue()
+    // static let itemLast: Item = kLSSharedFileListItemLast.takeRetainedValue()
+
+    @available(OSX, introduced=10.5, deprecated=10.11)
+    static func create(listType: String) -> List? {
+        return LSSharedFileListCreate(nil, listType, nil).takeRetainedValue() as List?
+    }
+
+    @available(OSX, introduced=10.5, deprecated=10.11)
+    static func insertItemURL(list: List, afterItem: Item, url: NSURL) -> Item {
+        return LSSharedFileListInsertItemURL(list, afterItem, nil, nil, url as CFURLRef, nil, nil).takeRetainedValue()
+    }
+
+    @available(OSX, introduced=10.5, deprecated=10.11)
+    static func removeItem(list: List, item: Item) {
+        LSSharedFileListItemRemove(list, item)
+    }
+
+    @available(OSX, introduced=10.5, deprecated=10.11)
+    static func copySnapshot(list: List) -> NSArray {
+        return LSSharedFileListCopySnapshot(list, nil).takeRetainedValue()
+    }
+
+    @available(OSX, introduced=10.10, deprecated=10.11)
+    static func copyResolvedURL(item: Item) -> NSURL? {
+        return LSSharedFileListItemCopyResolvedURL(item, 0, nil).takeRetainedValue()
+    }
+}


### PR DESCRIPTION
Closes #7.

I was hoping to implement so that toggling this in app item would just add the app to the System Preferences -> Login Item section. Same thing as if the user did it manually.

However, that required using the "Shared File List" APIs which seem to be recently deprecated as of 10.11. It works. But I'm unsure if Apple will remove it in the near future or may reject the app from the Mac App Store since it clearly targets a deprecated API.

The alternative is using this other "Service Management Framework" API. But it doesn't seem to modify the Login Item list so the user can only disable from within the app. Its also much more complicated.

https://developer.apple.com/library/mac/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLoginItems.html
