### PR TITLE
Marketing Page: Live Timers

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -4,3 +4,5 @@
     <p class="text-small text-muted">General inquiries &amp; support: <a href="mailto:{{ site.email | escape }}">{{ site.email | escape }}</a></p>
   </div>
 </footer>
+
+<script src="{{ "/assets/js/main.js" | prepend: site.baseurl }}" async></script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,6 +8,4 @@
 
   <link rel="stylesheet" href="{{ "/assets/css/main.css" | prepend: site.baseurl }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-
-  <script src="{{ "/assets/js/main.js" | prepend: site.baseurl }}" async></script>
 </head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,4 +8,6 @@
 
   <link rel="stylesheet" href="{{ "/assets/css/main.css" | prepend: site.baseurl }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+
+  <script src="{{ "/assets/js/main.js" | prepend: site.baseurl }}" async></script>
 </head>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,4 @@
+// Clicking menubar toggles "dark menu bar"
+document.querySelector('.menubar').addEventListener('click', function() {
+  this.classList.toggle('dark')
+})

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,4 +1,36 @@
-// Clicking menubar toggles "dark menu bar"
-document.querySelector('.menubar').addEventListener('click', function() {
-  this.classList.toggle('dark')
-})
+(function() {
+  // Clicking menubar toggles "dark menu bar"
+  document.querySelector('.js-toggle-dark-menubar').addEventListener('click', function() {
+    this.classList.toggle('dark');
+  });
+
+  var timer = document.querySelector('.js-aware-timer');
+  var pageLoad = new Date() - (Math.random() * 1000 * 60 * 30);
+  function updateTimer() {
+    var now = new Date();
+    var min = Math.floor((now - pageLoad) / (1000 * 60));
+    var text = min + "m";
+
+    timer.textContent = text;
+  }
+
+  var clock = document.querySelector('.js-clock');
+  function updateClock() {
+    var now = new Date();
+    var day = now.toUTCString().split(",")[0];
+    var hour = (now.getHours() % 12);
+    var min = ("0" + now.getMinutes()).slice(-2);
+    var meridian = now.getHours() > 12 ? "PM" : "AM";
+    var text = day + " " + hour + ":" + min + " " + meridian;
+
+    clock.textContent = text;
+  }
+
+  setInterval(function() {
+    updateTimer();
+    updateClock();
+  }, 30000);
+
+  updateTimer();
+  updateClock();
+})()

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@ layout: default
 <div class="container-wide">
   <div class="monitor">
     <div class="os">
-      <div class="menubar">
+      <div class="menubar js-toggle-dark-menubar">
         <ul class="menubar-menu menuleft">
           <li class="menuitem menuitem-svg menuitem-apple">
             <svg viewBox="0 0 28 32" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
@@ -35,7 +35,7 @@ layout: default
           <li class="menuitem">Help</li>
         </ul>
         <ul class="menubar-menu menuright">
-          <li class="menuitem menuitem-aware">2h 2m</li>
+          <li class="menuitem menuitem-aware js-aware-timer">0m</li>
           <li class="menuitem menuitem-svg menuitem-wifi">
             <svg viewBox="0 0 42 29" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <title>Icon - WiFi</title>
@@ -50,7 +50,7 @@ layout: default
                 </g>
             </svg>
           </li>
-          <li class="menuitem">Mon 12:20 AM</li>
+          <li class="menuitem js-clock">Mon 10:10 AM</li>
           <li class="menuitem menuitem-svg menuitem-search">
             <svg viewBox="0 0 28 27" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <title>Menubar - Spotlight</title>


### PR DESCRIPTION
From https://github.com/josh/Aware/issues/25

>  Create a switch to show dark menubar example.

I wasn't sure what should toggle the dark and light menubar, I just guessed, maybe clicking the menu bar itself? Have that hooked up to toggle a `.dark` css class

>  Write a little JS that makes the clock accurate to system time.

Done.

>  Write a little JS that will start the Aware timer on page load

Done. I initialized the timer to a random time on page load (between 0m and 30m). It starts counting from then on.
## 

To: @pmarsceill 
