### PR TITLE
Keep recording even if the user is 'idle'

### DIFF
--- a/Aware/AppDelegate.swift
+++ b/Aware/AppDelegate.swift
@@ -67,10 +67,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     func updateButton() {
         var idle: Bool
 
-        if (self.sinceUserActivity() > userIdleSeconds) {
-            timerStart = Date()
-            idle = true
-        } else if (CGDisplayIsAsleep(CGMainDisplayID()) == 1) {
+        if (CGDisplayIsAsleep(CGMainDisplayID()) == 1) {
             timerStart = Date()
             idle = true
         } else {

--- a/Aware/AppDelegate.swift
+++ b/Aware/AppDelegate.swift
@@ -47,7 +47,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let _ = Timer.scheduledTimer(buttonRefreshRate, userInfo: nil, repeats: true) { _ in self.updateButton() }
 
         let notificationCenter = NSWorkspace.shared.notificationCenter
-        notificationCenter.addObserver(forName: NSWorkspace.willSleepNotification, object: nil, queue: nil) { _ in self.resetTimer() }
+        notificationCenter.addObserver(forName: NSWorkspace.willSleepNotification, object: nil, queue: nil) { _ in self.saveTimer() }
         notificationCenter.addObserver(forName: NSWorkspace.didWakeNotification, object: nil, queue: nil) { _ in self.resetTimer() }
     }
 
@@ -64,6 +64,35 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         updateButton()
     }
 
+    func dateToday() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MMMM-dd"
+        return dateFormatter.string(from: Date())
+    }
+    
+    func saveTimer() {
+        let duration = String(Date().timeIntervalSince(timerStart))
+        let today = self.dateToday()
+        let data = duration + ":" + today + "\n"
+        if let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
+            
+            // add a filename
+            let fileUrl = documents.appendingPathComponent("AwareData.txt")
+            do {
+                // read till end of file so we can append the data
+                let fileHandle = try FileHandle(forWritingTo: fileUrl)
+                fileHandle.seekToEndOfFile()
+                fileHandle.write(data.data(using: .utf8)!)
+                fileHandle.closeFile()
+            }
+            catch {
+                print("Error writing to file \(error)")
+            }
+        }
+        
+        resetTimer()
+    }
+    
     func updateButton() {
         var idle: Bool
 

--- a/Aware/AppDelegate.swift
+++ b/Aware/AppDelegate.swift
@@ -47,7 +47,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let _ = Timer.scheduledTimer(buttonRefreshRate, userInfo: nil, repeats: true) { _ in self.updateButton() }
 
         let notificationCenter = NSWorkspace.shared.notificationCenter
-        notificationCenter.addObserver(forName: NSWorkspace.willSleepNotification, object: nil, queue: nil) { _ in self.saveTimer() }
+        notificationCenter.addObserver(forName: NSWorkspace.willSleepNotification, object: nil, queue: nil) { _ in self.resetTimer() }
         notificationCenter.addObserver(forName: NSWorkspace.didWakeNotification, object: nil, queue: nil) { _ in self.resetTimer() }
     }
 
@@ -64,35 +64,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         updateButton()
     }
 
-    func dateToday() -> String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MMMM-dd"
-        return dateFormatter.string(from: Date())
-    }
-    
-    func saveTimer() {
-        let duration = String(Date().timeIntervalSince(timerStart))
-        let today = self.dateToday()
-        let data = duration + ":" + today + "\n"
-        if let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
-            
-            // add a filename
-            let fileUrl = documents.appendingPathComponent("AwareData.txt")
-            do {
-                // read till end of file so we can append the data
-                let fileHandle = try FileHandle(forWritingTo: fileUrl)
-                fileHandle.seekToEndOfFile()
-                fileHandle.write(data.data(using: .utf8)!)
-                fileHandle.closeFile()
-            }
-            catch {
-                print("Error writing to file \(error)")
-            }
-        }
-        
-        resetTimer()
-    }
-    
     func updateButton() {
         var idle: Bool
 

--- a/Aware/AppDelegate.swift
+++ b/Aware/AppDelegate.swift
@@ -48,7 +48,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let notificationCenter = NSWorkspace.shared.notificationCenter
         notificationCenter.addObserver(forName: NSWorkspace.willSleepNotification, object: nil, queue: nil) { _ in self.saveTimer() }
-        notificationCenter.addObserver(forName: NSWorkspace.didWakeNotification, object: nil, queue: nil) { _ in self.rebootTimer() }
+        notificationCenter.addObserver(forName: NSWorkspace.didWakeNotification, object: nil, queue: nil) { _ in self.resetTimer() }
     }
 
     func resetTimer() {
@@ -93,36 +93,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         resetTimer()
     }
     
-    func rebootTimer() {
-        if let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
-            let fileUrl = documents.appendingPathComponent("awareData.txt")
-            let today = self.dateToday() + "\n"
-            do {
-                // open the data file
-                let text = try String(contentsOf: fileUrl, encoding: .utf8)
-                
-                // get the last line of the file (aka the most recent one)
-                let dataSlice = text.components(separatedBy: .newlines).suffix(2)
-                let data = dataSlice[dataSlice.startIndex]
-                
-                // get duration by fetching the strings before the colon (the data format is 'duration':'date')
-                let duration = Int(Float(data.components(separatedBy: ":").first!)!)
-                
-                // get the date by fetching the string after the colon
-                let date = text.components(separatedBy: ":").last!
-                if date == today {
-                    timerStart = Date(timeIntervalSinceNow: TimeInterval(-duration))
-                }
-                else {
-                    resetTimer()
-                }
-            }
-            catch {
-                print("error reading the file \(error)")
-            }
-        }
-    }
-        
     func updateButton() {
         var idle: Bool
 

--- a/Aware/AppDelegate.swift
+++ b/Aware/AppDelegate.swift
@@ -48,7 +48,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let notificationCenter = NSWorkspace.shared.notificationCenter
         notificationCenter.addObserver(forName: NSWorkspace.willSleepNotification, object: nil, queue: nil) { _ in self.saveTimer() }
-        notificationCenter.addObserver(forName: NSWorkspace.didWakeNotification, object: nil, queue: nil) { _ in self.resetTimer() }
+        notificationCenter.addObserver(forName: NSWorkspace.didWakeNotification, object: nil, queue: nil) { _ in self.rebootTimer() }
     }
 
     func resetTimer() {
@@ -93,6 +93,36 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         resetTimer()
     }
     
+    func rebootTimer() {
+        if let documents = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
+            let fileUrl = documents.appendingPathComponent("awareData.txt")
+            let today = self.dateToday() + "\n"
+            do {
+                // open the data file
+                let text = try String(contentsOf: fileUrl, encoding: .utf8)
+                
+                // get the last line of the file (aka the most recent one)
+                let dataSlice = text.components(separatedBy: .newlines).suffix(2)
+                let data = dataSlice[dataSlice.startIndex]
+                
+                // get duration by fetching the strings before the colon (the data format is 'duration':'date')
+                let duration = Int(Float(data.components(separatedBy: ":").first!)!)
+                
+                // get the date by fetching the string after the colon
+                let date = text.components(separatedBy: ":").last!
+                if date == today {
+                    timerStart = Date(timeIntervalSinceNow: TimeInterval(-duration))
+                }
+                else {
+                    resetTimer()
+                }
+            }
+            catch {
+                print("error reading the file \(error)")
+            }
+        }
+    }
+        
     func updateButton() {
         var idle: Bool
 


### PR DESCRIPTION
The user may have been watching some movie or youtube video and was not interacting with the computer for some time. Even though this removes the edge case of desktop computers, I think the widget should track how much the computer has been turned on. (or allow some customization)